### PR TITLE
fix: Actuator Endpoint 개방

### DIFF
--- a/src/main/kotlin/com/template/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/template/security/config/SecurityConfig.kt
@@ -44,10 +44,12 @@ class SecurityConfig(private val jwtTokenUtil: JwtTokenUtil, private val authent
 
     override fun configure(web: WebSecurity?) {
         // TODO: JWT 인증 절차를 제외할 End point 추가 및 수정
-        web?.ignoring()
-            ?.mvcMatchers(HttpMethod.POST, "/v1/auth/update-token")
-            ?.mvcMatchers(HttpMethod.POST, "/v1/auth/login")
-            ?.mvcMatchers(HttpMethod.GET, "/swagger-ui/**")
+        web!!
+        web.ignoring()
+            .mvcMatchers(HttpMethod.POST, "/v1/auth/update-token")
+            .mvcMatchers(HttpMethod.POST, "/v1/auth/login")
+            .mvcMatchers(HttpMethod.GET, "/swagger-ui/**")
+            .mvcMatchers(HttpMethod.GET, "/actuator/**")
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,5 +15,12 @@ spring:
     password: ${DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+info:
+  application:
+    author: Sangwoo Ra(robbyra@gmail.com)
+    version: 0.1.0
+    description: Template repository for building Spring Boot(MVC) Applications using Kotlin
+    more_info: https://github.com/sang-w0o/spring-boot-kotlin-template
+
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/kotlin/com/template/ActuatorTest.kt
+++ b/src/test/kotlin/com/template/ActuatorTest.kt
@@ -1,0 +1,35 @@
+package com.template
+
+import org.junit.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.RequestEntity
+import java.net.URI
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ActuatorTest : ApiIntegrationTest() {
+
+    @Test
+    fun healthCheckApiIsOpen() {
+        val requestEntity = RequestEntity.get(URI.create("/actuator/health"))
+            .build()
+        val responseEntity = restTemplate.exchange(requestEntity, String::class.java)
+        val response = responseEntity.body
+        assertEquals(HttpStatus.OK, responseEntity.statusCode)
+        assertTrue(response.contains("status"))
+        assertTrue(response.contains("UP"))
+    }
+
+    @Test
+    fun infoApiIsOpen() {
+        val requestEntity = RequestEntity.get(URI.create("/actuator/info"))
+            .build()
+        val responseEntity = restTemplate.exchange(requestEntity, String::class.java)
+        val response = responseEntity.body
+        assertEquals(HttpStatus.OK, responseEntity.statusCode)
+        assertTrue(response.contains("author"))
+        assertTrue(response.contains("version"))
+        assertTrue(response.contains("description"))
+        assertTrue(response.contains("more_info"))
+    }
+}


### PR DESCRIPTION
- Spring Boot Actuator가 제공하는 기본적인 API Endpoing(`/actuator/health`, `actuator/info`) 개방
- `actuator/info`에 소개 문구 추가
