### PR TITLE
feat: 테스트 코드 리팩토링

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,17 +31,16 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt:0.9.1")
     implementation("io.springfox:springfox-boot-starter:3.0.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    testImplementation(kotlin("test-junit"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit:4.13.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
     testImplementation("com.h2database:h2")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.11")
 }
 
 tasks.test {
-    useJUnit()
+    useJUnitPlatform()
 }
 
-tasks.withType<KotlinCompile>() {
+tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
 }

--- a/src/main/kotlin/com/template/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/template/auth/service/AuthService.kt
@@ -33,7 +33,7 @@ class AuthService(private val jwtTokenUtil: JwtTokenUtil,
         if(!encoder.matches(requestDto.password, user.password)) throw LoginException()
         return LoginResponseDto(
             accessToken = jwtTokenUtil.generateAccessToken(user.id!!),
-            refreshToken = jwtTokenUtil.generateAccessToken(user.id!!),
+            refreshToken = jwtTokenUtil.generateAccessToken(user.id),
         )
     }
 }

--- a/src/main/kotlin/com/template/security/handler/JWTAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/template/security/handler/JWTAuthenticationEntryPoint.kt
@@ -1,7 +1,6 @@
 package com.template.security.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.template.common.dto.ErrorResponseDto

--- a/src/main/kotlin/com/template/security/service/JWTUserDetailsService.kt
+++ b/src/main/kotlin/com/template/security/service/JWTUserDetailsService.kt
@@ -2,7 +2,6 @@ package com.template.security.service
 
 import com.template.common.function.AuthorizeUser
 import org.springframework.security.core.GrantedAuthority
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Service

--- a/src/test/kotlin/com/template/ActuatorTest.kt
+++ b/src/test/kotlin/com/template/ActuatorTest.kt
@@ -1,24 +1,23 @@
 package com.template
 
-import com.jayway.jsonpath.JsonPath
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.get
 import java.net.URI
 
 class ActuatorTest : ApiIntegrationTest() {
 
+    @DisplayName("Actuator - Health Check")
     @Test
     fun healthCheckApiIsOpen() {
         val test = mockMvc.get(URI.create("/actuator/health"))
-        val result = test.andExpect {
+        test.andExpect {
             status { isOk() }
-            jsonPath("status") { exists() }
-        }.andReturn()
-        val statusResult = JsonPath.read<String>(result.response.contentAsString, "$.status")
-        assertEquals("UP", statusResult)
+            jsonPath("status") { value("UP")}
+        }
    }
 
+    @DisplayName("Actuator - Information")
     @Test
     fun infoApiIsOpen() {
         val test = mockMvc.get(URI.create("/actuator/info"))

--- a/src/test/kotlin/com/template/ActuatorTest.kt
+++ b/src/test/kotlin/com/template/ActuatorTest.kt
@@ -1,35 +1,33 @@
 package com.template
 
-import org.junit.Test
-import org.springframework.http.HttpStatus
-import org.springframework.http.RequestEntity
+import com.jayway.jsonpath.JsonPath
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.get
 import java.net.URI
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class ActuatorTest : ApiIntegrationTest() {
 
     @Test
     fun healthCheckApiIsOpen() {
-        val requestEntity = RequestEntity.get(URI.create("/actuator/health"))
-            .build()
-        val responseEntity = restTemplate.exchange(requestEntity, String::class.java)
-        val response = responseEntity.body
-        assertEquals(HttpStatus.OK, responseEntity.statusCode)
-        assertTrue(response.contains("status"))
-        assertTrue(response.contains("UP"))
-    }
+        val test = mockMvc.get(URI.create("/actuator/health"))
+        val result = test.andExpect {
+            status { isOk() }
+            jsonPath("status") { exists() }
+        }.andReturn()
+        val statusResult = JsonPath.read<String>(result.response.contentAsString, "$.status")
+        assertEquals("UP", statusResult)
+   }
 
     @Test
     fun infoApiIsOpen() {
-        val requestEntity = RequestEntity.get(URI.create("/actuator/info"))
-            .build()
-        val responseEntity = restTemplate.exchange(requestEntity, String::class.java)
-        val response = responseEntity.body
-        assertEquals(HttpStatus.OK, responseEntity.statusCode)
-        assertTrue(response.contains("author"))
-        assertTrue(response.contains("version"))
-        assertTrue(response.contains("description"))
-        assertTrue(response.contains("more_info"))
-    }
+        val test = mockMvc.get(URI.create("/actuator/info"))
+        test.andExpect {
+            status { isOk() }
+            jsonPath("application.author") { exists() }
+            jsonPath("application.version") { exists() }
+            jsonPath("application.description") { exists() }
+            jsonPath("application.more_info") { exists() }
+        }
+   }
 }

--- a/src/test/kotlin/com/template/ApiIntegrationTest.kt
+++ b/src/test/kotlin/com/template/ApiIntegrationTest.kt
@@ -1,25 +1,22 @@
 package com.template
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.template.auth.exception.UserIdNotFoundException
 import com.template.auth.tools.JwtTokenUtil
 import com.template.domain.user.User
 import com.template.domain.user.UserRepository
-import org.junit.After
-import org.junit.Before
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.http.HttpStatus
-import org.springframework.http.RequestEntity
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
-import kotlin.test.assertEquals
+import org.springframework.test.web.servlet.MockMvc
 
-@RunWith(SpringRunner::class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @ActiveProfiles("test")
+@AutoConfigureMockMvc
 abstract class ApiIntegrationTest {
 
     companion object {
@@ -32,7 +29,7 @@ abstract class ApiIntegrationTest {
     protected lateinit var userRepository: UserRepository
 
     @Autowired
-    protected lateinit var restTemplate: TestRestTemplate
+    protected lateinit var mockMvc: MockMvc
 
     @Autowired
     protected lateinit var jwtTokenUtil: JwtTokenUtil
@@ -40,38 +37,25 @@ abstract class ApiIntegrationTest {
     @Autowired
     protected lateinit var encoder: BCryptPasswordEncoder
 
-    @Before
+    @Autowired
+    protected lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
     fun setUp() {
         val user = User(
             email = EMAIL,
             name = NAME,
             password = encoder.encode(PASSWORD))
-        val a = userRepository.save(user)
+        userRepository.save(user)
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         userRepository.deleteAll()
     }
 
     protected fun getUserId(): Int {
         val user = userRepository.findByEmail(EMAIL).orElseThrow{ UserIdNotFoundException() }
-        val userId = user.id
-        if(userId != null) return userId
-        else return -1
-    }
-
-    protected fun getUser(): User {
-        return userRepository.findByEmail(EMAIL).orElseThrow { UserIdNotFoundException() }
-    }
-
-    protected fun assertResponseStatus(httpStatus: HttpStatus, requestEntity: RequestEntity<*>) {
-        val responseEntity = restTemplate.exchange(requestEntity, String::class.java)
-        assertEquals(httpStatus, responseEntity.statusCode)
-    }
-
-    protected fun saveUser(email: String, name: String, password: String) {
-        val user = User(email, name, password)
-        userRepository.save(user)
+        return user.id ?: -1
     }
 }

--- a/src/test/kotlin/com/template/ApiIntegrationTest.kt
+++ b/src/test/kotlin/com/template/ApiIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MockMvcResultMatchersDsl
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -57,5 +58,14 @@ abstract class ApiIntegrationTest {
     protected fun getUserId(): Int {
         val user = userRepository.findByEmail(EMAIL).orElseThrow{ UserIdNotFoundException() }
         return user.id ?: -1
+    }
+
+    protected fun assertErrorResponse(dsl: MockMvcResultMatchersDsl) {
+        dsl.jsonPath("timestamp") { exists() }
+        dsl.jsonPath("status") { exists() }
+        dsl.jsonPath("error") { exists() }
+        dsl.jsonPath("message") { exists() }
+        dsl.jsonPath("path") { exists() }
+        dsl.jsonPath("remote") { exists() }
     }
 }

--- a/src/test/kotlin/com/template/auth/AccessTokenUpdateTest.kt
+++ b/src/test/kotlin/com/template/auth/AccessTokenUpdateTest.kt
@@ -50,12 +50,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
         }
         test.andExpect {
             status { isUnauthorized() }
-            jsonPath("timestamp") { exists() }
-            jsonPath("status") { exists() }
-            jsonPath("error") { exists() }
-            jsonPath("message") { exists() }
-            jsonPath("path") { exists() }
-            jsonPath("remote") { exists() }
+            assertErrorResponse(this)
         }
     }
 
@@ -68,12 +63,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
         }
         test.andExpect {
             status { isUnauthorized() }
-            jsonPath("timestamp") { exists() }
-            jsonPath("status") { exists() }
-            jsonPath("error") { exists() }
-            jsonPath("message") { exists() }
-            jsonPath("path") { exists() }
-            jsonPath("remote") { exists() }
+            assertErrorResponse(this)
         }
     }
 
@@ -87,12 +77,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
         }
         test.andExpect {
             status { isUnauthorized() }
-            jsonPath("timestamp") { exists() }
-            jsonPath("status") { exists() }
-            jsonPath("error") { exists() }
-            jsonPath("message") { exists() }
-            jsonPath("path") { exists() }
-            jsonPath("remote") { exists() }
+            assertErrorResponse(this)
         }
     }
 

--- a/src/test/kotlin/com/template/auth/LoginTest.kt
+++ b/src/test/kotlin/com/template/auth/LoginTest.kt
@@ -1,27 +1,20 @@
 package com.template.auth
 
+import com.jayway.jsonpath.JsonPath
 import com.template.ApiIntegrationTest
 import com.template.auth.dto.LoginRequestDto
-import com.template.auth.dto.LoginResponseDto
-import org.junit.Test
-import org.springframework.http.HttpStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
-import org.springframework.http.RequestEntity
+import org.springframework.test.web.servlet.post
 import java.net.URI
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 class LoginTest : ApiIntegrationTest() {
 
     companion object {
         const val WRONG_EMAIL = "wrong@wrong.com"
         const val WRONG_PASSWORD = "wrongPassword"
-    }
-
-    private fun getLoginRequestEntity(requestDto: LoginRequestDto): RequestEntity<LoginRequestDto> {
-        return RequestEntity.post(URI.create("/v1/auth/login"))
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(requestDto)
     }
 
     private fun getLoginRequestDto(email: String, password: String): LoginRequestDto {
@@ -32,37 +25,66 @@ class LoginTest : ApiIntegrationTest() {
     }
 
     @Test
+    @DisplayName("로그인 성공")
     fun login_responseIsOkIfAllConditionsAreRight() {
         val userId = getUserId()
         val requestDto = getLoginRequestDto(EMAIL, PASSWORD)
-        val requestEntity = getLoginRequestEntity(requestDto)
-        val responseEntity = restTemplate.exchange(requestEntity, LoginResponseDto::class.java)
 
-        assertEquals(HttpStatus.OK, responseEntity.statusCode)
-        val responseBody = responseEntity.body
-        assertNotNull(responseBody.accessToken)
-        assertNotNull(responseBody.refreshToken)
+        val test = mockMvc.post(URI.create("/v1/auth/login")) {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(requestDto)
+        }
 
-        val accessToken = responseBody.accessToken
-        val refreshToken = responseBody.refreshToken
+        val result = test.andExpect {
+            status { isOk() }
+            jsonPath("accessToken") { exists() }
+            jsonPath("refreshToken") { exists() }
+        }.andReturn()
+
+        val accessToken = JsonPath.read<String>(result.response.contentAsString, "$.accessToken")
+        val refreshToken = JsonPath.read<String>(result.response.contentAsString, "$.refreshToken")
 
         assertEquals(userId, jwtTokenUtil.extractUserId(accessToken))
         assertEquals(userId, jwtTokenUtil.extractUserId(refreshToken))
     }
 
     @Test
+    @DisplayName("로그인 실패 - 없는 이메일")
     fun login_responseIsNotFoundIfEmailIsWrong() {
         val requestDto = getLoginRequestDto(WRONG_EMAIL, PASSWORD)
-        val requestEntity = getLoginRequestEntity(requestDto)
+        val test = mockMvc.post(URI.create("/v1/auth/login")) {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(requestDto)
+        }
 
-        assertResponseStatus(HttpStatus.NOT_FOUND, requestEntity)
+        test.andExpect {
+            status { isNotFound() }
+            jsonPath("timestamp") { exists() }
+            jsonPath("status") { exists() }
+            jsonPath("error") { exists() }
+            jsonPath("message") { exists() }
+            jsonPath("path") { exists() }
+            jsonPath("remote") { exists() }
+        }
     }
 
     @Test
+    @DisplayName("로그인 실패 - 비밀번호 오류")
     fun login_responseIsNotFoundIfPasswordIsWrong() {
         val requestDto = getLoginRequestDto(EMAIL, WRONG_PASSWORD)
-        val requestEntity = getLoginRequestEntity(requestDto)
+        val test = mockMvc.post(URI.create("/v1/auth/login")) {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(requestDto)
+        }
 
-        assertResponseStatus(HttpStatus.NOT_FOUND, requestEntity)
+        test.andExpect {
+            status { isNotFound() }
+            jsonPath("timestamp") { exists() }
+            jsonPath("status") { exists() }
+            jsonPath("error") { exists() }
+            jsonPath("message") { exists() }
+            jsonPath("path") { exists() }
+            jsonPath("remote") { exists() }
+        }
     }
 }

--- a/src/test/kotlin/com/template/auth/LoginTest.kt
+++ b/src/test/kotlin/com/template/auth/LoginTest.kt
@@ -38,11 +38,6 @@ class LoginTest : ApiIntegrationTest() {
         val userId = getUserId()
         val requestDto = getLoginRequestDto(EMAIL, PASSWORD)
 
-        val test = mockMvc.post(URI.create("/v1/auth/login")) {
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(requestDto)
-        }
-
         val result = apiCall(requestDto).andExpect {
             status { isOk() }
             jsonPath("accessToken") { exists() }
@@ -60,12 +55,8 @@ class LoginTest : ApiIntegrationTest() {
     @DisplayName("로그인 실패 - 없는 이메일")
     fun login_responseIsNotFoundIfEmailIsWrong() {
         val requestDto = getLoginRequestDto(WRONG_EMAIL, PASSWORD)
-        val test = mockMvc.post(URI.create("/v1/auth/login")) {
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(requestDto)
-        }
 
-        test.andExpect {
+        apiCall(requestDto).andExpect {
             status { isNotFound() }
             assertErrorResponse(this)
         }
@@ -75,12 +66,7 @@ class LoginTest : ApiIntegrationTest() {
     @DisplayName("로그인 실패 - 비밀번호 오류")
     fun login_responseIsNotFoundIfPasswordIsWrong() {
         val requestDto = getLoginRequestDto(EMAIL, WRONG_PASSWORD)
-        val test = mockMvc.post(URI.create("/v1/auth/login")) {
-            contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(requestDto)
-        }
-
-        test.andExpect {
+        apiCall(requestDto).andExpect {
             status { isNotFound() }
             assertErrorResponse(this)
         }

--- a/src/test/kotlin/com/template/auth/LoginTest.kt
+++ b/src/test/kotlin/com/template/auth/LoginTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.ResultActionsDsl
 import org.springframework.test.web.servlet.post
 import java.net.URI
 
@@ -24,6 +25,13 @@ class LoginTest : ApiIntegrationTest() {
         return requestDto
     }
 
+    private fun apiCall(requestDto: LoginRequestDto): ResultActionsDsl {
+        return mockMvc.post(URI.create("/v1/auth/login")) {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(requestDto)
+        }
+    }
+
     @Test
     @DisplayName("로그인 성공")
     fun login_responseIsOkIfAllConditionsAreRight() {
@@ -35,7 +43,7 @@ class LoginTest : ApiIntegrationTest() {
             content = objectMapper.writeValueAsString(requestDto)
         }
 
-        val result = test.andExpect {
+        val result = apiCall(requestDto).andExpect {
             status { isOk() }
             jsonPath("accessToken") { exists() }
             jsonPath("refreshToken") { exists() }
@@ -59,12 +67,7 @@ class LoginTest : ApiIntegrationTest() {
 
         test.andExpect {
             status { isNotFound() }
-            jsonPath("timestamp") { exists() }
-            jsonPath("status") { exists() }
-            jsonPath("error") { exists() }
-            jsonPath("message") { exists() }
-            jsonPath("path") { exists() }
-            jsonPath("remote") { exists() }
+            assertErrorResponse(this)
         }
     }
 
@@ -79,12 +82,7 @@ class LoginTest : ApiIntegrationTest() {
 
         test.andExpect {
             status { isNotFound() }
-            jsonPath("timestamp") { exists() }
-            jsonPath("status") { exists() }
-            jsonPath("error") { exists() }
-            jsonPath("message") { exists() }
-            jsonPath("path") { exists() }
-            jsonPath("remote") { exists() }
+            assertErrorResponse(this)
         }
     }
 }


### PR DESCRIPTION
- chore: Use JUnit-Jupiter-Api 5.7 instead of JUnit4
- feat: Upgrade test codes to use JUnit5
- chore: Refactor error case response assertion code - method extraction
- chore: Refactor mockmvc preparing code - Method Extraction

<h2>주요 변경 사항</h2>

- JUnit4 에서 JUnit5로 마이그레이션
- `TestRestTemplate`과 `RequestEntity`, `ResponseEntity`를 버리고 `MockMvc` 사용
