### PR TITLE
feat: Use byte array for JWT Secret key

### DIFF
--- a/src/main/kotlin/com/template/auth/tools/JwtTokenUtil.kt
+++ b/src/main/kotlin/com/template/auth/tools/JwtTokenUtil.kt
@@ -36,7 +36,7 @@ class JwtTokenUtil(
 
     private fun extractAllClaims(token: String): Claims {
         try {
-            return Jwts.parser().setSigningKey(jwtProperties.secret).parseClaimsJws(token).body
+            return Jwts.parser().setSigningKey(jwtProperties.secret.toByteArray()).parseClaimsJws(token).body
         } catch (expiredJwtException: ExpiredJwtException) {
             throw AuthenticateException("Jwt 토큰이 만료되었습니다.")
         } catch (unsupportedJwtException: UnsupportedJwtException) {
@@ -55,7 +55,7 @@ class JwtTokenUtil(
             .setClaims(claims)
             .setIssuedAt(Date(System.currentTimeMillis()))
             .setExpiration(Date(System.currentTimeMillis() + exp))
-            .signWith(SignatureAlgorithm.HS256, jwtProperties.secret)
+            .signWith(SignatureAlgorithm.HS256, jwtProperties.secret.toByteArray())
             .compact()
     }
 

--- a/src/test/kotlin/com/template/integration/auth/AccessTokenUpdateTest.kt
+++ b/src/test/kotlin/com/template/integration/auth/AccessTokenUpdateTest.kt
@@ -84,7 +84,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
             .setClaims(claims)
             .setIssuedAt(Date(System.currentTimeMillis() - 86400000 * 8))
             .setExpiration(Date(System.currentTimeMillis() - 86400000 * 7))
-            .signWith(SignatureAlgorithm.HS256, secretKey)
+            .signWith(SignatureAlgorithm.HS256, secretKey.toByteArray())
             .compact()
     }
 }

--- a/src/test/kotlin/com/template/unit/BaseUnitTest.kt
+++ b/src/test/kotlin/com/template/unit/BaseUnitTest.kt
@@ -41,7 +41,7 @@ abstract class BaseUnitTest {
             .setClaims(mutableMapOf())
             .setIssuedAt(Date(System.currentTimeMillis()))
             .setExpiration(Date(System.currentTimeMillis() + EXTRA_TIME))
-            .signWith(SignatureAlgorithm.HS256, jwtProperties.secret)
+            .signWith(SignatureAlgorithm.HS256, jwtProperties.secret.toByteArray())
             .compact()
     }
 }

--- a/src/test/kotlin/com/template/unit/auth/JwtTokenUtilTest.kt
+++ b/src/test/kotlin/com/template/unit/auth/JwtTokenUtilTest.kt
@@ -81,7 +81,7 @@ class JwtTokenUtilTest : BaseUnitTest() {
             .setClaims(mutableMapOf())
             .setIssuedAt(Date(System.currentTimeMillis()))
             .setExpiration(Date(System.currentTimeMillis() + EXTRA_TIME))
-            .signWith(SignatureAlgorithm.HS256, jwtProperties.secret)
+            .signWith(SignatureAlgorithm.HS256, jwtProperties.secret.toByteArray())
             .compact()
         val exception = shouldThrow<AuthenticateException> { jwtTokenUtil.extractUserId(wrongToken) }
         exception.message shouldBe "JWT Claim에 userId가 없습니다."

--- a/src/test/kotlin/com/template/util/TestUtils.kt
+++ b/src/test/kotlin/com/template/util/TestUtils.kt
@@ -22,7 +22,7 @@ fun generateExpiredToken(exp: Int, secret: String): String {
         .setClaims(claims)
         .setIssuedAt(Date(System.currentTimeMillis() - realExp))
         .setExpiration(Date(System.currentTimeMillis() - EXTRA_TIME))
-        .signWith(SignatureAlgorithm.HS256, secret)
+        .signWith(SignatureAlgorithm.HS256, secret.toByteArray())
         .compact()
 }
 


### PR DESCRIPTION
- JWT Secret key를 사용하는 부분(JWT 발급, 검증)에서 `String`이 아닌 `byte[]` 타입으로 secret key를 변경해 사용하도록 변경
